### PR TITLE
MOD: Modified links to accomodate github pages

### DIFF
--- a/docs/overrides/landing.html
+++ b/docs/overrides/landing.html
@@ -156,10 +156,10 @@
                         <a href="#how-it-works"
                             class="text-gray-700 hover:text-gray-900 transition font-bold  hover:border-b-2 hover:border-red-ossiq">
                             How it works</a>
-                        <a href="/getting-started/"
+                        <a href="/ossiq/getting-started/"
                             class="text-gray-700 hover:text-gray-900 transition font-bold hover:border-b-2 hover:border-red-ossiq">Getting
                             started</a>
-                        <a href="/explanation/"
+                        <a href="/ossiq/explanation/"
                             class="text-gray-700 hover:text-gray-900 transition font-bold  hover:border-b-2 hover:border-red-ossiq">Explanation</a>
                         <a href="#faq"
                             class="text-gray-700 hover:text-gray-900 transition font-bold  hover:border-b-2 hover:border-red-ossiq">
@@ -167,7 +167,7 @@
                     </div>
                 </div>
                 <div class="flex items-center space-x-4">
-                    <a href="https://github.com/" class="flex items-center space-x-1 text-gray-700
+                    <a href="https://github.com/ossiq/ossiq/" class="flex items-center space-x-1 text-gray-700
                             hover:text-black transition font-medium">
                         <span class="material-symbols-rounded text-xl">code</span>
                         <span>GitHub</span>
@@ -429,8 +429,9 @@
                 <div>
                     <h4 class="text-white font-semibold mb-4">Project</h4>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="/explanation/" class="hover:text-white transition">Explanation</a></li>
-                        <li><a href="/getting-started/" class="hover:text-white transition">Documentation</a></li>
+                        <li><a href="/ossiq/explanation/" class="hover:text-white transition">Explanation</a></li>
+                        <li><a href="/ossiq/getting-started/" class="hover:text-white transition">Documentation</a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: ossiq
 site_description: "Utility to forecast risks associated with currently installed packages updates"
 site_author: Maksym Klymyshyn
 site_dir: site
-site_url: https://ossiq.github.io
+site_url: https://ossiq.github.io/ossiq/
 
 repo_name: ossiq/ossiq
 repo_url: https://github.com/ossiq/ossiq


### PR DESCRIPTION
The way github pages works is a bit different than default configuration of MkDocs. Now fixed.

GH-1