### PR TITLE
MOD: Added custom domain name ossiq.dev

### DIFF
--- a/docs/overrides/landing.html
+++ b/docs/overrides/landing.html
@@ -156,10 +156,10 @@
                         <a href="#how-it-works"
                             class="text-gray-700 hover:text-gray-900 transition font-bold  hover:border-b-2 hover:border-red-ossiq">
                             How it works</a>
-                        <a href="/ossiq/getting-started/"
+                        <a href="/getting-started/"
                             class="text-gray-700 hover:text-gray-900 transition font-bold hover:border-b-2 hover:border-red-ossiq">Getting
                             started</a>
-                        <a href="/ossiq/explanation/"
+                        <a href="/explanation/"
                             class="text-gray-700 hover:text-gray-900 transition font-bold  hover:border-b-2 hover:border-red-ossiq">Explanation</a>
                         <a href="#faq"
                             class="text-gray-700 hover:text-gray-900 transition font-bold  hover:border-b-2 hover:border-red-ossiq">
@@ -429,8 +429,8 @@
                 <div>
                     <h4 class="text-white font-semibold mb-4">Project</h4>
                     <ul class="space-y-2 text-sm">
-                        <li><a href="/ossiq/explanation/" class="hover:text-white transition">Explanation</a></li>
-                        <li><a href="/ossiq/getting-started/" class="hover:text-white transition">Documentation</a>
+                        <li><a href="/explanation/" class="hover:text-white transition">Explanation</a></li>
+                        <li><a href="/getting-started/" class="hover:text-white transition">Documentation</a>
                         </li>
                     </ul>
                 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: ossiq
 site_description: "Utility to forecast risks associated with currently installed packages updates"
 site_author: Maksym Klymyshyn
 site_dir: site
-site_url: https://ossiq.github.io/ossiq/
+site_url: https://ossiq.dev/
 
 repo_name: ossiq/ossiq
 repo_url: https://github.com/ossiq/ossiq


### PR DESCRIPTION
Added custom domain ossiq.dev instead of
github pages default domain which is a subfolder.

GH-1